### PR TITLE
Fix for case sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This release support **Notifications**.
   
 ### Changed
 
-- `@Handler` is now deprecated use `@requestHandler` instead.
+- `@Handler` is now deprecated use `@RequestHandler` instead.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This release support **Notifications**.
   
 ### Changed
 
-- `@Handler` is now deprecated use `@RequestHandler` instead.
+- `@Handler` is now deprecated use `@requestHandler` instead.
 
 ### Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See the [Wiki](https://github.com/m4ss1m0g/mediatr-ts/wiki) for more details
 
 ## Request Handler
 
-Below the `RequestHandler` pattern with internal resolver and with the inversify library
+Below the `requestHandler` pattern with internal resolver and with the inversify library
 
 ### Internal resolver
 
@@ -28,7 +28,7 @@ class Request implements IRequest<string> {
 }
 
 // handlertest.ts -> Add the attribute to the request handler
-@RequestHandler(Request)
+@requestHandler(Request)
 class HandlerTest implements IRequestHandler<Request, string> {
     handle(value: Request): Promise<string> {
         return Promise.resolve(`Value passed ${value.name}`);
@@ -50,7 +50,7 @@ const result = await mediator.send<string>(r);
 
 ### Inversify resolver
 
-At the very beginning of your app you **MUST** setup the resolver with inversify, or at least **BEFORE** using the `@RequestHandler` attribute and/or the `Mediator` class.
+At the very beginning of your app you **MUST** setup the resolver with inversify, or at least **BEFORE** using the `@requestHandler` attribute and/or the `Mediator` class.
 
 ```typescript
 import container from "whatever";
@@ -114,7 +114,7 @@ class Request implements IRequest<number> {
 
 // Decorate the handler request with Handler and injectable attribute, notice the warrior property
 
-@RequestHandler(Request)
+@requestHandler(Request)
 @injectable()
 class HandlerRequest implements IRequestHandler<Request, string> {
     @inject(TYPES.IWarrior)
@@ -133,7 +133,7 @@ const result = await mediator.send<string>(new Request(99));
 
 ## Notification Handler
 
-Below a simple example without Inversify. If you want Inversify to resolve the `NotificationHandler` you should configure the `resolver` property of `mediatorSettings` see the `RequestHandler` example above.
+Below a simple example without Inversify. If you want Inversify to resolve the `NotificationHandler` you should configure the `resolver` property of `mediatorSettings` see the `requestHandler` example above.
 
 ```typescript
 const result: string[] = [];

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ const result = await mediator.send<string>(new Request(99));
 
 ## Notification Handler
 
-Below a simple example without Inversify. If you want Inversify to resolve the `NotificationHandler` you should configure the `resolver` property of `mediatorSettings` see the `requestHandler` example above.
+Below a simple example without Inversify. If you want Inversify to resolve the `notificationHandler` you should configure the `resolver` property of `mediatorSettings` see the `requestHandler` example above.
 
 ```typescript
 const result: string[] = [];
@@ -144,7 +144,7 @@ class Ping implements INotification {
 }
 
 // The notification handler
-@NotificationHandler(Ping, 1)
+@notificationHandler(Ping, 1)
 class Pong1 implements INotificationHandler<Ping> {
 
     async handle(notification: Ping): Promise<void> {
@@ -162,4 +162,4 @@ mediator.publish(new Ping(message));
 
 The `resolver` can be plugged in with other DI containers, it's enought to implemente the `IResolver` interface and setup the `resolver` property of `mediatorSettings` (like the `Inversify` provider).
 
-The `NotificationHandler` can be rewritten implementing the `IDispatcher` and setup the `dispatcher` property of `mediatorSettings`.
+The `notificationHandler` can be rewritten implementing the `IDispatcher` and setup the `dispatcher` property of `mediatorSettings`.

--- a/src/attributes/notification.attribute.ts
+++ b/src/attributes/notification.attribute.ts
@@ -4,12 +4,12 @@ import DispatchInstance from "@/models/dispatch.instance";
 import settings from "@/settings";
 
 /**
- * Decorate the NotificationHandler with this attribute
+ * Decorate the notificationHandler with this attribute
  * 
  * @param value The request type
  * @param order The order of event
  */
-const NotificationHandler = (value: INotification, order?: number) => {
+const notificationHandler = (value: INotification, order?: number) => {
     return (target: Function): void => {
         const eventName = (value as Function).prototype.constructor.name;
         const handlerName = (target as Function).prototype.constructor.name;
@@ -18,4 +18,4 @@ const NotificationHandler = (value: INotification, order?: number) => {
     };
 };
 
-export default NotificationHandler;
+export default notificationHandler;

--- a/src/attributes/request.attribute.ts
+++ b/src/attributes/request.attribute.ts
@@ -3,15 +3,15 @@ import IRequest from "@/interfaces/irequest";
 import settings from "@/settings";
 
 /**
- * Decorate the RequestHandler with this attribute
+ * Decorate the requestHandler with this attribute
  * 
  * @param value The request type
  */
-const RequestHandler = <T>(value: IRequest<T>) => {
+const requestHandler = <T>(value: IRequest<T>) => {
     return (target: Function): void => {
         const name = (value as Function).prototype.constructor.name;
         settings.resolver.add(name, target);
     };
 };
 
-export default RequestHandler;
+export default requestHandler;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import requestHandler from "@/attributes/request.attribute";
 
 import INotification from "@/interfaces/inotification";
 import INotificationHandler from "@/interfaces/inotification.handler";
-import NotificationHandler from "@/attributes/notification.attribute";
+import notificationHandler from "@/attributes/notification.attribute";
 
 import IDispatcher from "@/interfaces/idispatcher";
 import IResolver from "@/interfaces/iresolver";
@@ -22,7 +22,7 @@ export {
     requestHandler,
 
     INotification,
-    NotificationHandler,
+    notificationHandler,
     INotificationHandler,
 
     IDispatcher,
@@ -44,3 +44,8 @@ export const Handler = requestHandler;
  * @deprecated Use requestHandler instead
  */
 export const RequestHandler = requestHandler;
+
+/**
+ * @deprecated Use notificationHandler instead
+ */
+export const NotificationHandler = notificationHandler;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 
 import IRequest from "@/interfaces/irequest";
 import IRequestHandler from "@/interfaces/irequest.handler";
-import RequestHandler from "@/attributes/request.attribute";
+import requestHandler from "@/attributes/request.attribute";
 
 import INotification from "@/interfaces/inotification";
 import INotificationHandler from "@/interfaces/inotification.handler";
@@ -19,7 +19,7 @@ import DispatchInstance from "@/models/dispatch.instance";
 export {
     IRequest,
     IRequestHandler,
-    RequestHandler,
+    requestHandler,
 
     INotification,
     NotificationHandler,
@@ -36,6 +36,11 @@ export {
 };
 
 /**
- * @deprecated Use RequestHandler instead
+ * @deprecated Use requestHandler instead
  */
-export const Handler = RequestHandler;
+export const Handler = requestHandler;
+
+/**
+ * @deprecated Use requestHandler instead
+ */
+export const RequestHandler = requestHandler;

--- a/test/notification.attribute.internal.spec.ts
+++ b/test/notification.attribute.internal.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import INotification from "@/interfaces/inotification";
-import NotificationHandler from "@/attributes/notification.attribute";
+import notificationHandler from "@/attributes/notification.attribute";
 import INotificationHandler from "@/interfaces/inotification.handler";
 import { Mediator, mediatorSettings } from "@/index";
 
@@ -20,7 +20,7 @@ describe("The notification attribute", () => {
         const spyResolver = jest.spyOn(mediatorSettings.resolver, "add");
 
         // Act
-        @NotificationHandler(Ping, 1)
+        @notificationHandler(Ping, 1)
         class Pong1 implements INotificationHandler<Ping> {
             handle(notification: Ping): Promise<void> {
                 throw new Error("Method not implemented.");
@@ -39,7 +39,7 @@ describe("The notification attribute", () => {
         const result: string[] = [];
         const message = "foo";
 
-        @NotificationHandler(Ping, 1)
+        @notificationHandler(Ping, 1)
         class Pong1 implements INotificationHandler<Ping> {
 
             async handle(notification: Ping): Promise<void> {
@@ -61,7 +61,7 @@ describe("The notification attribute", () => {
         const result: string[] = [];
         const message1 = "foo1";
 
-        @NotificationHandler(Ping, 2)
+        @notificationHandler(Ping, 2)
         class Pong2 implements INotificationHandler<Ping> {
 
             async handle(notification: Ping): Promise<void> {
@@ -69,7 +69,7 @@ describe("The notification attribute", () => {
             }
         }
 
-        @NotificationHandler(Ping, 1)
+        @notificationHandler(Ping, 1)
         class Pong1 implements INotificationHandler<Ping> {
 
             async handle(notification: Ping): Promise<void> {
@@ -92,7 +92,7 @@ describe("The notification attribute", () => {
         const result: string[] = [];
         const message = "foo";
 
-        @NotificationHandler(Ping)
+        @notificationHandler(Ping)
         class Pong1 implements INotificationHandler<Ping> {
 
             async handle(notification: Ping): Promise<void> {
@@ -100,7 +100,7 @@ describe("The notification attribute", () => {
             }
         }
 
-        @NotificationHandler(Ping)
+        @notificationHandler(Ping)
         class Pong2 implements INotificationHandler<Ping> {
 
             async handle(notification: Ping): Promise<void> {

--- a/test/notification.attribute.inversify.spec.ts
+++ b/test/notification.attribute.inversify.spec.ts
@@ -7,7 +7,7 @@ import {
     IResolver,
     mediatorSettings,
     INotification,
-    NotificationHandler,
+    notificationHandler,
     INotificationHandler,
 } from "@/index";
 import { injectable, Container, inject } from "inversify";
@@ -66,7 +66,7 @@ describe("Notification with inversify", () => {
         // Settings the resolver with Inversify
         mediatorSettings.resolver = new InversifyResolver();
 
-        @NotificationHandler(Ping)
+        @notificationHandler(Ping)
         @injectable()
         class Foo implements INotificationHandler<Ping> {
             @inject(TYPES.IWarrior)

--- a/test/request.handler.attrbute.inversify.spec.ts
+++ b/test/request.handler.attrbute.inversify.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import "reflect-metadata";
-import { Mediator, IRequestHandler, IResolver, mediatorSettings, IRequest, RequestHandler } from "@/index";
+import { Mediator, IRequestHandler, IResolver, mediatorSettings, IRequest, requestHandler } from "@/index";
 import { injectable, Container, inject } from "inversify";
 
 describe("Resolver with inversify", () => {
@@ -86,7 +86,7 @@ describe("Resolver with inversify", () => {
             }
         }
 
-        @RequestHandler(Request)
+        @requestHandler(Request)
         @injectable()
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         class HandlerRequest implements IRequestHandler<Request, string> {

--- a/test/request.handler.attribute.internal.spec.ts
+++ b/test/request.handler.attribute.internal.spec.ts
@@ -1,4 +1,4 @@
-import { Mediator, Handler, IRequestHandler, mediatorSettings, RequestHandler } from "@/index";
+import { Mediator, Handler, IRequestHandler, mediatorSettings, requestHandler } from "@/index";
 import Resolver from "@/models/resolver";
 
 describe("Resolver with local container", () => {
@@ -15,7 +15,7 @@ describe("Resolver with local container", () => {
             name: string;
         }
 
-        @RequestHandler(Request)
+        @requestHandler(Request)
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         class HandlerTest implements IRequestHandler<Request, string> {
             handle(value: Request): Promise<string> {


### PR DESCRIPTION
Decorators in JavaScript or TypeScript are with `camelCase`.