### PR TITLE
add missing file extensions and update jest moduleNameMapper to cater…

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -35,7 +35,7 @@ export default {
 
   // A list of reporter names that Jest uses when writing coverage reports
   "coverageReporters": [
-    "json-summary", 
+    "json-summary",
     "text",
     "lcov"
   ],
@@ -81,7 +81,8 @@ export default {
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
-    "@/(.*)\\.js$": ["<rootDir>/src/$1"]
+    "^@/(.*)\\.js$": ["<rootDir>/src/$1"],
+    "^(?!.*node_modules)(.*?/.+)\\.js?$": "$1"
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/src/attributes/requestHandler.attribute.ts
+++ b/src/attributes/requestHandler.attribute.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { RequestHandlerClass } from "@/interfaces/requestHandler";
+import { RequestHandlerClass } from "@/interfaces/requestHandler.js";
 import { typeMappings } from "@/models/mappings/index.js";
 import type { RequestDataClass } from "@/models/requestData.js";
 import RequestData from "@/models/requestData.js";
 
 /**
  * Decorate the requestHandler with this attribute
- * 
+ *
  * @param value The request type
  */
 const requestHandler = <T>(value: RequestDataClass<T>) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import type { Class } from "@/interfaces/resolver.js";
 import type PipelineBehavior from "@/interfaces/pipelineBehavior.js";
 import pipelineBehavior from "@/attributes/pipelineBehavior.attribute.js";
 
-import Mediator from "./models/mediator";
+import Mediator from "./models/mediator.js";
 
 export {
     RequestData,

--- a/src/interfaces/requestHandler.ts
+++ b/src/interfaces/requestHandler.ts
@@ -1,9 +1,9 @@
-import type RequestData from "../models/requestData";
+import type RequestData from "../models/requestData.js";
 
 /**
  * The Request Handler interface
- * 
- * @exports 
+ *
+ * @exports
  * @interface RequestHandler
  */
 export default interface RequestHandler<TInput extends RequestData<TOutput>, TOutput> {

--- a/src/models/instantiationResolver.ts
+++ b/src/models/instantiationResolver.ts
@@ -1,4 +1,4 @@
-import Resolver, { Class } from "@/interfaces/resolver";
+import Resolver, { Class } from "@/interfaces/resolver.js";
 
 /**
  * The default resolver.

--- a/src/models/mappings/index.ts
+++ b/src/models/mappings/index.ts
@@ -1,6 +1,6 @@
-import { NotificationHandlerMappings } from "./notificationHandlerMappings";
-import { PipelineBehaviorMappings } from "./pipelineBehaviorMappings";
-import { RequestHandlerMappings } from "./requestHandlerMappings";
+import { NotificationHandlerMappings } from "./notificationHandlerMappings.js";
+import { PipelineBehaviorMappings } from "./pipelineBehaviorMappings.js";
+import { RequestHandlerMappings } from "./requestHandlerMappings.js";
 
 export const typeMappings = {
     pipelineBehaviors: new PipelineBehaviorMappings(),

--- a/src/models/mappings/notificationHandlerMappings.ts
+++ b/src/models/mappings/notificationHandlerMappings.ts
@@ -1,25 +1,25 @@
-import { NotificationHandlerClass } from "@/interfaces/notificationHandler";
-import { NotificationClass } from "../notificationData";
-import { byOrder, OrderedMapping, OrderedMappings } from "./orderedMappings";
+import { NotificationHandlerClass } from "@/interfaces/notificationHandler.js";
+import { NotificationClass } from "../notificationData.js";
+import { byOrder, OrderedMapping, OrderedMappings } from "./orderedMappings.js";
 
-type NotificationHandlerMappingData = { 
+type NotificationHandlerMappingData = {
     handlerClass: NotificationHandlerClass<unknown>,
     notificationClass: NotificationClass
 };
 
 /**
- * NotificationHandlerMappings class extends OrderedMappings and is used to 
+ * NotificationHandlerMappings class extends OrderedMappings and is used to
  * manage notification handlers for specific notification classes.
- * 
+ *
  * @exports
  */
 export class NotificationHandlerMappings extends OrderedMappings<NotificationHandlerMappingData> {
 
     /**
-     * It allows you to specify the order in which notification handlers should be executed for a particular 
+     * It allows you to specify the order in which notification handlers should be executed for a particular
      * notification class.
-     * 
-     * It takes a notification class and an array of handler classes as input and updates the order of each handler in 
+     *
+     * It takes a notification class and an array of handler classes as input and updates the order of each handler in
      * the array based on its index. If not found it place the order as -1.
      *
      * @param notificationClass The notification class for which to set the order.
@@ -33,12 +33,12 @@ export class NotificationHandlerMappings extends OrderedMappings<NotificationHan
     }
 
     /**
-     * Retrieves all notification handlers for a specific notification class. 
-     * If no class is provided, it returns all handlers. 
+     * Retrieves all notification handlers for a specific notification class.
+     * If no class is provided, it returns all handlers.
      * If no handlers are found for the specified class, it throws an error.
-     * 
+     *
      * The returned handlers are sorted by their order.
-     * 
+     *
      * @param notificationClass The notification class for which to retrieve the handlers.
      * @returns The array of handler classes in the order in which they should be executed.
      */

--- a/src/models/mappings/pipelineBehaviorMappings.ts
+++ b/src/models/mappings/pipelineBehaviorMappings.ts
@@ -1,25 +1,25 @@
-import { PipelineBehaviorClass } from "@/interfaces/pipelineBehavior";
-import { OrderedMappings, OrderedMapping, byOrder } from "./orderedMappings";
+import { PipelineBehaviorClass } from "@/interfaces/pipelineBehavior.js";
+import { OrderedMappings, OrderedMapping, byOrder } from "./orderedMappings.js";
 
 type PipelineBehaviorData = {
     behaviorClass: PipelineBehaviorClass
 };
 
 /**
- * The PipelineBehaviorMappings class is a subclass of OrderedMappings that is used to manage a collection of 
- * PipelineBehaviorData objects. 
- * 
+ * The PipelineBehaviorMappings class is a subclass of OrderedMappings that is used to manage a collection of
+ * PipelineBehaviorData objects.
+ *
  * @exports
  */
 export class PipelineBehaviorMappings extends OrderedMappings<PipelineBehaviorData> {
 
     /**
-     * This method takes an array of PipelineBehaviorClass objects and sets the order of each item in the _internal_ collection 
+     * This method takes an array of PipelineBehaviorClass objects and sets the order of each item in the _internal_ collection
      * based on index in the array passed in.
-     * 
-     * It takes a behaviour class as input and updates the order of each item in the the array based on its index. 
+     *
+     * It takes a behaviour class as input and updates the order of each item in the the array based on its index.
      * If not found it place the order as -1.
-     * 
+     *
      * @param behaviorClasses The ordered list of pipeline behavior classes
      */
     public setOrder(behaviorClasses: PipelineBehaviorClass[]) {
@@ -30,8 +30,8 @@ export class PipelineBehaviorMappings extends OrderedMappings<PipelineBehaviorDa
     }
 
     /**
-     * This method returns a sorted array of all the items in the collection. 
-     * 
+     * This method returns a sorted array of all the items in the collection.
+     *
      * @returns The array of handler classes in the order in which they should be executed.
      */
     public getAll(): OrderedMapping<PipelineBehaviorData>[] {

--- a/src/models/mappings/requestHandlerMappings.ts
+++ b/src/models/mappings/requestHandlerMappings.ts
@@ -1,15 +1,15 @@
-import { RequestHandlerClass } from "@/interfaces/requestHandler";
-import RequestData, { RequestDataClass } from "../requestData";
-import { byOrder, OrderedMapping, OrderedMappings } from "./orderedMappings";
+import { RequestHandlerClass } from "@/interfaces/requestHandler.js";
+import RequestData, { RequestDataClass } from "../requestData.js";
+import { byOrder, OrderedMapping, OrderedMappings } from "./orderedMappings.js";
 
-type RequestHandlerMappingData = { 
+type RequestHandlerMappingData = {
     handlerClass: RequestHandlerClass<RequestData<unknown>, unknown>,
     requestClass: RequestDataClass<unknown>
 };
 
 /**
  * Mapping for request handlers
- * 
+ *
  * @exports
  */
 
@@ -17,7 +17,7 @@ export class RequestHandlerMappings extends OrderedMappings<RequestHandlerMappin
 
     /**
      * Gets all mappings for a specific request if provided, otherwise returns all (sorted) mappings
-     * 
+     *
      * @throws Error if no mappings are found for specified argument
      * @param requestClass The request class to get mappings for
      * @returns The array of handler classes in the order in which they should be executed.

--- a/src/models/mediator.ts
+++ b/src/models/mediator.ts
@@ -4,10 +4,10 @@ import type { NotificationClass } from "@/models/notificationData.js";
 import type NotificationHandler from "@/interfaces/notificationHandler.js";
 import type RequestData from "@/models/requestData.js";
 import type PipelineBehavior from "@/interfaces/pipelineBehavior.js";
-import Resolver, { Class } from "@/interfaces/resolver";
-import RequestHandler from "@/interfaces/requestHandler";
+import Resolver, { Class } from "@/interfaces/resolver.js";
+import RequestHandler from "@/interfaces/requestHandler.js";
 import { typeMappings } from "@/models/mappings/index.js";
-import { InstantiationResolver } from "./instantiationResolver";
+import { InstantiationResolver } from "./instantiationResolver.js";
 
 type Settings = {
     resolver: Resolver;
@@ -57,7 +57,7 @@ export default class Mediator {
      * This method registers types with a resolver.
      * If custom settings are provided, it uses the resolver from those settings;
      * otherwise, it defaults to a new InstantiationResolver where add method is not used
-     * 
+     *
      * @param resolver The resolver
      */
     private registerTypesInResolver(resolver: Resolver) {
@@ -149,7 +149,7 @@ export default class Mediator {
         const handlerClasses = typeMappings.requestHandlers.getAll(
             request.constructor as Class<RequestData<TResult>>
         );
-        
+
         const handler = this._resolver.resolve(
             handlerClasses[0].handlerClass as unknown as Class<
                 RequestHandler<RequestData<TResult>, TResult>


### PR DESCRIPTION
This PR addresses #30.

It adds file extensions to the relative and other imports that was missing them and updates the jest config to deal with the relative imports that now has file extensions.